### PR TITLE
fix(deps): reqwest 0.13 renamed rustls-tls feature to rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ flate2 = "1.0"
 urlencoding = "2.1"
 
 # OIDC/JWKS - HTTP client for fetching JWKS
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 
 # Cedar Policy Engine - authorization
 cedar-policy = "4.2"


### PR DESCRIPTION
Resolves CI failures since 2026-04-12. reqwest 0.13.x renamed the `rustls-tls` feature to `rustls` (with `__rustls` as internal alias). One-line fix in Cargo.toml.